### PR TITLE
use escape char to differentiate formatting from literal backslash

### DIFF
--- a/lib/asciidoctor/converter/manpage.rb
+++ b/lib/asciidoctor/converter/manpage.rb
@@ -9,20 +9,20 @@ module Asciidoctor
     LF = "\n"
     TAB = "\t"
     ETAB = ' ' * 8
+    ESC = "\u001b"
 
     # Converts HTML entity references back to their original form, escapes
     # special man characters and strips trailing whitespace.
+    #
+    # It's crucial that text only ever pass through manify once.
     #
     # Optional features:
     # * fold each endline into a single space
     # * append a newline
     def manify str, opts = {}
-      append_newline = opts[:append_newline]
-      preserve_space = opts.fetch :preserve_space, true
-      str = preserve_space ? str.gsub(TAB, ETAB) : str.tr_s(%(#{LF}#{TAB} ), ' ')
-      str = str.
-        gsub(/\\(?!f(?:B|I|P|\[CR\])|0|\()/, '\\(rs'). # literal backslash (ignores \fB, \fI, \fP, \f[CR], \0 & \( sequences)
-        gsub(/^\.$/, '\\\&.'). # lone . is also used in troff to indicate paragraph continuation with visual separator
+      str = ((opts.fetch :preserve_space, true) ? (str.gsub TAB, ETAB) : (str.tr_s %(#{LF}#{TAB} ), ' ')).
+        gsub('\\', '\\(rs').      # literal backslash
+        gsub(/^\.$/, '\\\&.').    # lone . is also used in troff to indicate paragraph continuation with visual separator
         gsub(/^\.((?:URL|MTO) ".*?" ".*?" )( |[^\s]*)(.*?)( *)$/, ".\\1\"\\2\"#{LF}\\c\\3"). # quote last URL argument
         gsub(/(?:\A\n|\n *(\n))^\.(URL|MTO) /, "\\1\.\\2 "). # strip blank lines in source that precede a URL
         gsub('-', '\\-').
@@ -46,8 +46,9 @@ module Asciidoctor
         gsub('&#8203;', '\:').    # zero width space
         gsub('\'', '\\(aq').      # apostrophe-quote
         gsub(/<\/?BOUNDARY>/, '').# artificial boundary
+        gsub(ESC, '\\').          # restore backslash used for escape sequences (NOTE could be applied on document content)
         rstrip                    # strip trailing space
-      append_newline ? %(#{str}#{LF}) : str
+      opts[:append_newline] ? %(#{str}#{LF}) : str
     end
 
     def skip_with_warning node, name = nil
@@ -67,12 +68,12 @@ module Asciidoctor
 .\\"    Author: #{(node.attr? 'authors') ? (node.attr 'authors') : '[see the "AUTHORS" section]'}
 .\\" Generator: Asciidoctor #{node.attr 'asciidoctor-version'}
 .\\"      Date: #{docdate = node.attr 'docdate'}
-.\\"    Manual: #{manual = (node.attr? 'manmanual') ? (node.attr 'manmanual') : '\ \&'}
-.\\"    Source: #{source = (node.attr? 'mansource') ? (node.attr 'mansource') : '\ \&'}
+.\\"    Manual: #{(manual = node.attr 'manmanual') || '\ \&'}
+.\\"    Source: #{(source = node.attr 'mansource') || '\ \&'}
 .\\"  Language: English
 .\\")]
       # TODO add document-level setting to disable capitalization of manname
-      result << %(.TH "#{manify manname.upcase}" "#{manvolnum}" "#{docdate}" "#{manify source}" "#{manify manual}")
+      result << %(.TH "#{manify manname.upcase}" "#{manvolnum}" "#{docdate}" "#{source ? (manify source) : '\ \&'}" "#{manual ? (manify manual) : '\ \&'}")
       # define portability settings
       # see http://bugs.debian.org/507673
       # see http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
@@ -573,11 +574,11 @@ allbox tab(:);'
         if (text = node.text) == target
           text = nil
         else
-          text = text.gsub '"', '\\(dq'
+          text = text.gsub '"', %[#{ESC}(dq]
         end
         if target.start_with? 'mailto:'
           macro = 'MTO'
-          target = target[7..-1].sub('@', '\\(at')
+          target = target[7..-1].sub '@', %[#{ESC}(at]
         else
           macro = 'URL'
         end
@@ -599,11 +600,11 @@ allbox tab(:);'
     end
 
     def inline_button node
-      %(\\fB[\\0#{node.text}\\0]\\fP)
+      %(#{ESC}fB[#{ESC}0#{node.text}#{ESC}0]#{ESC}fP)
     end
 
     def inline_callout node
-      %[\\fB(#{node.text})\\fP]
+      %(#{ESC}fB(#{node.text})#{ESC}fP)
     end
 
     # TODO supposedly groff has footnotes, but we're in search of an example
@@ -629,20 +630,20 @@ allbox tab(:);'
       if (keys = node.attr 'keys').size == 1
         keys[0]
       else
-        keys.join '\0+\0'
+        keys.join %(#{ESC}0+#{ESC}0)
       end
     end
 
     def inline_menu node
-      caret = '\0\(fc\0'
+      caret = %[#{ESC}0#{ESC}(fc#{ESC}0]
       menu = node.attr 'menu'
       if !(submenus = node.attr 'submenus').empty?
-        submenu_path = submenus.map {|item| %(\\fI#{item}\\fP) }.join caret
-        %(\\fI#{menu}\\fP#{caret}#{submenu_path}#{caret}\\fI#{node.attr 'menuitem'}\\fP)
+        submenu_path = submenus.map {|item| %(#{ESC}fI#{item}#{ESC}fP) }.join caret
+        %(#{ESC}fI#{menu}#{ESC}fP#{caret}#{submenu_path}#{caret}#{ESC}fI#{node.attr 'menuitem'}#{ESC}fP)
       elsif (menuitem = node.attr 'menuitem')
-        %(\\fI#{menu}#{caret}#{menuitem}\\fP)
+        %(#{ESC}fI#{menu}#{caret}#{menuitem}#{ESC}fP)
       else
-        %(\\fI#{menu}\\fP)
+        %(#{ESC}fI#{menu}#{ESC}fP)
       end
     end
 
@@ -650,15 +651,15 @@ allbox tab(:);'
     def inline_quoted node
       case node.type
       when :emphasis
-        %[\\fI<BOUNDARY>#{node.text}</BOUNDARY>\\fP]
+        %(#{ESC}fI<BOUNDARY>#{node.text}</BOUNDARY>#{ESC}fP)
       when :strong
-        %[\\fB<BOUNDARY>#{node.text}</BOUNDARY>\\fP]
+        %(#{ESC}fB<BOUNDARY>#{node.text}</BOUNDARY>#{ESC}fP)
       when :monospaced
-        %[\\f[CR]<BOUNDARY>#{node.text}</BOUNDARY>\\fP]
+        %(#{ESC}f[CR]<BOUNDARY>#{node.text}</BOUNDARY>#{ESC}fP)
       when :single
-        %[\\(oq<BOUNDARY>#{node.text}</BOUNDARY>\\(cq]
+        %[#{ESC}(oq<BOUNDARY>#{node.text}</BOUNDARY>#{ESC}(cq]
       when :double
-        %[\\(lq<BOUNDARY>#{node.text}</BOUNDARY>\\(rq]
+        %[#{ESC}(lq<BOUNDARY>#{node.text}</BOUNDARY>#{ESC}(rq]
       else
         node.text
       end

--- a/test/manpage_test.rb
+++ b/test/manpage_test.rb
@@ -1,0 +1,70 @@
+# encoding: UTF-8
+unless defined? ASCIIDOCTOR_PROJECT_DIR
+  $: << File.dirname(__FILE__); $:.uniq!
+  require 'test_helper'
+end
+
+SAMPLE_MANPAGE_HEADER = <<-EOS.chomp
+= command (1)
+Author Name
+:doctype: manpage
+:man manual: Command Manual
+:man source: Command 1.2.3
+
+== NAME
+
+command - does stuff
+
+== SYNOPSIS
+
+*command* [_OPTION_]... _FILE_...
+
+== DESCRIPTION
+EOS
+
+context 'Manpage' do
+  context 'Manify' do
+    test 'should escape lone period' do
+      input = %(#{SAMPLE_MANPAGE_HEADER}
+
+.)
+      output = Asciidoctor.convert input, :backend => :manpage
+      assert_equal '\&.', output.lines.last.chomp
+    end
+  end
+
+  context 'Backslash' do
+    test 'should not escape spaces for empty manual or source fields' do
+      input = SAMPLE_MANPAGE_HEADER.lines.select {|l| !l.start_with?(':man ') }
+      output = Asciidoctor.convert input, :backend => :manpage, :header_footer => true
+      assert_match ' Manual: \ \&', output
+      assert_match ' Source: \ \&', output
+      assert_match(/^\.TH "COMMAND" .* "\\ \\&" "\\ \\&"$/, output)
+    end
+
+    test 'should preserve backslashes in escape sequences' do
+      input = %(#{SAMPLE_MANPAGE_HEADER}
+
+"`hello`" '`goodbye`' *strong* _weak_ `even`)
+      output = Asciidoctor.convert input, :backend => :manpage
+      assert_equal '\(lqhello\(rq \(oqgoodbye\(cq \fBstrong\fP \fIweak\fP \f[CR]even\fP', output.lines.last.chomp
+    end
+
+    test 'should escape backslashes in content' do
+      input = %(#{SAMPLE_MANPAGE_HEADER}
+
+\\.foo \\ bar\\
+baz)
+      output = Asciidoctor.convert input, :backend => :manpage
+      assert_equal '\(rs.foo \(rs bar\(rs', output.lines[-2].chomp
+    end
+
+    test 'should escape literal escape sequence' do
+      input = %(#{SAMPLE_MANPAGE_HEADER}
+
+ \\fB makes text bold)
+      output = Asciidoctor.convert input, :backend => :manpage
+      assert_match '\(rsfB makes text bold', output
+    end
+  end
+end


### PR DESCRIPTION
- use escape character to differentiate formatting marks from literal backslash
- add tests for manpage backend
- consolidate manify method